### PR TITLE
Leaflabs usb warning

### DIFF
--- a/STM32F1/cores/maple/libmaple/usb/stm32f1/usb_cdcacm.c
+++ b/STM32F1/cores/maple/libmaple/usb/stm32f1/usb_cdcacm.c
@@ -62,8 +62,8 @@
 
 #if !(defined(BOARD_maple) || defined(BOARD_maple_RET6) ||      \
       defined(BOARD_maple_mini) || defined(BOARD_maple_native))
-#warning USB CDC ACM relies on LeafLabs board-specific configuration.\
-    You may have problems on non-LeafLabs boards.
+//#warning USB CDC ACM relies on LeafLabs board-specific configuration.\
+//    You may have problems on non-LeafLabs boards.
 #endif
 
 static void vcomDataTxCb(void);


### PR DESCRIPTION
Remove annoying warnig "USB CDC ACM relies on LeafLabs board-specific configuration."
